### PR TITLE
[WIJ-8] Deploy Backend to Akash Network

### DIFF
--- a/.ralph_state/tasks/wij-8.md
+++ b/.ralph_state/tasks/wij-8.md
@@ -1,0 +1,5 @@
+# WIJ-8: Deploy Backend to Akash Network
+
+This branch is for implementing: Deploy the AgentBond backend to Akash decentralized cloud. Create valid SDL file and configure resources.
+
+Linear Issue: https://linear.app/wijnaldum/issue/WIJ-8/deploy-backend-to-akash-network


### PR DESCRIPTION
# WIJ-8: Deploy Backend to Akash Network

## Linear Issue
https://linear.app/wijnaldum/issue/WIJ-8/deploy-backend-to-akash-network

## Task Description
Deploy the AgentBond backend to Akash decentralized cloud. Create valid SDL file and configure resources.

## Instructions for Copilot
@github-copilot implement this feature following AgentBond patterns and existing code architecture.
