### PR TITLE
[WIJ-9] Connect Frontend to Real Backend API

### DIFF
--- a/.ralph_state/tasks/wij-9.md
+++ b/.ralph_state/tasks/wij-9.md
@@ -1,0 +1,5 @@
+# WIJ-9: Connect Frontend to Real Backend API
+
+This branch is for implementing: Update frontend to use real backend endpoints instead of mock data. Implement proper error states.
+
+Linear Issue: https://linear.app/wijnaldum/issue/WIJ-9/connect-frontend-to-real-backend-api


### PR DESCRIPTION
# WIJ-9: Connect Frontend to Real Backend API

## Linear Issue
https://linear.app/wijnaldum/issue/WIJ-9/connect-frontend-to-real-backend-api

## Task Description
Update frontend to use real backend endpoints instead of mock data. Implement proper error states.

## Instructions for Copilot
@github-copilot implement this feature following AgentBond patterns and existing code architecture.
